### PR TITLE
Text block migration

### DIFF
--- a/app/src/main/java/com/example/translateocrapp/LanguageRecognizer.kt
+++ b/app/src/main/java/com/example/translateocrapp/LanguageRecognizer.kt
@@ -23,7 +23,7 @@ class LanguageRecognizer {
         languageIdentifierClient = LanguageIdentification.getClient(languageIdentifierOptions)
     }
 
-    fun recognizeLanguage(ocrMap: Map<Rect, Text.Line>): String {
+    fun recognizeLanguage(ocrMap: Map<Rect, Text.TextBlock>): String {
 
         // Iterate through the map of OCR results and recognize the language of each line
         // Find the most common language that is either German or Swedish
@@ -33,9 +33,9 @@ class LanguageRecognizer {
         val languageMap = mutableMapOf<Rect, String>()
 
         // Iterate through the map of OCR results
-        for ((rect, line) in ocrMap) {
+        for ((rect, textBlock) in ocrMap) {
             // Get the text from the line
-            val text = line.text
+            val text = textBlock.text
 
             // Create a task to recognize the language of the line
             val task: Task<String> = languageIdentifierClient.identifyLanguage(text)

--- a/app/src/main/java/com/example/translateocrapp/LanguageRecognizer.kt
+++ b/app/src/main/java/com/example/translateocrapp/LanguageRecognizer.kt
@@ -25,7 +25,7 @@ class LanguageRecognizer {
 
     fun recognizeLanguage(ocrMap: Map<Rect, Text.TextBlock>): String {
 
-        // Iterate through the map of OCR results and recognize the language of each line
+        // Iterate through the map of OCR results and recognize the language of each textBlock
         // Find the most common language that is either German or Swedish
         // if neither German nor Swedish is found, return "und"
 
@@ -34,16 +34,16 @@ class LanguageRecognizer {
 
         // Iterate through the map of OCR results
         for ((rect, textBlock) in ocrMap) {
-            // Get the text from the line
+            // Get the text from the textBlock
             val text = textBlock.text
 
-            // Create a task to recognize the language of the line
+            // Create a task to recognize the language of the textBlock
             val task: Task<String> = languageIdentifierClient.identifyLanguage(text)
 
             // Wait for the task to complete
             val result = Tasks.await(task)
 
-            // Store the language of the line in the map
+            // Store the language of the textBlock in the map
             languageMap[rect] = result
         }
 

--- a/app/src/main/java/com/example/translateocrapp/OcrHelper.kt
+++ b/app/src/main/java/com/example/translateocrapp/OcrHelper.kt
@@ -23,27 +23,27 @@ class OcrHelper {
     }
 
 
-    fun performOcr(bitmap: Bitmap): Map<Rect, Text.Line> {
+    fun performOcr(bitmap: Bitmap): Map<Rect, Text.TextBlock> {
         val image = InputImage.fromBitmap(bitmap, 0)
         val task: Task<Text> = textRecognizer.process(image)
         val result = Tasks.await(task)
         return extractTextBlocks(result)
     }
 
-    private fun extractTextBlocks(text: Text): Map<Rect, Text.Line> {
-        val lineMap = mutableMapOf<Rect, Text.Line>()
+    private fun extractTextBlocks(text: Text): Map<Rect, Text.TextBlock> {
+        val blockMap = mutableMapOf<Rect, Text.TextBlock>()
 
         for (textBlock in text.textBlocks) {
-            for (line in textBlock.lines) {
-                val rect = line.boundingBox
 
-                if (rect != null) {
-                    lineMap[rect] = line
-                }
+            val rect = textBlock.boundingBox
+
+            if (rect != null) {
+                blockMap[rect] = textBlock
+
             }
         }
 
-        return lineMap
+        return blockMap
     }
 
 

--- a/app/src/main/java/com/example/translateocrapp/PreviewActivity.kt
+++ b/app/src/main/java/com/example/translateocrapp/PreviewActivity.kt
@@ -49,7 +49,7 @@ class PreviewActivity : AppCompatActivity() {
     private val textTranslator = TextTranslator(this)
 
     // Create a variable to store the OCR result
-    private lateinit var ocrResultMap: Map<Rect, Text.Line>
+    private lateinit var ocrResultMap: Map<Rect, Text.TextBlock>
 
     // Create a variable to store the language detected
     private lateinit var languageCode: String
@@ -151,10 +151,11 @@ class PreviewActivity : AppCompatActivity() {
     }
 
     // Create a function to process the OCR result
-    private fun processOcrResult(ocrResultMap: Map<Rect, Text.Line>) {
+    private fun processOcrResult(ocrResultMap: Map<Rect, Text.TextBlock>) {
         // Log the OCR result with Rect and text
-        for ((rect, textLine) in ocrResultMap) {
-            Log.d("OCR", "Found text ${textLine.text} at $rect")
+        for ((rect, textBlock) in ocrResultMap) {
+            Log.d("OCR", "Found text ${textBlock.text} at $rect")
+
         }
 
     }

--- a/app/src/main/java/com/example/translateocrapp/TextTranslator.kt
+++ b/app/src/main/java/com/example/translateocrapp/TextTranslator.kt
@@ -154,16 +154,16 @@ class TextTranslator(private val context: Context) {
     }
 
     // Create a function to translate ocr result
-    fun translateOcrResult(ocrResult: Map<Rect, Text.Line>, languageCode: String ): Map<Rect, String> {
+    fun translateOcrResult(ocrResult: Map<Rect, Text.TextBlock>, languageCode: String ): Map<Rect, String> {
 
         // Create a map to store the translated result
         val translatedResult = mutableMapOf<Rect, String>()
 
         // Iterate through the ocr result
-        for ((rect, line) in ocrResult) {
+        for ((rect, textBlock) in ocrResult) {
 
-            // Translate the line to english
-            val translatedText = translateTextToEnglish(line.text, languageCode)
+            // Translate the textBlock text to english
+            val translatedText = translateTextToEnglish(textBlock.text, languageCode)
 
             // Add the translated text to the map
             translatedResult[rect] = translatedText


### PR DESCRIPTION
We use textBlocks to translate blocks of text at a time instead of line by line, thus increasing translation accuracy.
We also modified the bitmap annotator to work with text blocks instead of lines, and fill text into rectangular regions with text warping.